### PR TITLE
Harden npm supply chain: ignore dependency install scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ API Client library for [Data Graphs](https://datagraphs.com)
 
 Documentation for the Data Graphs API can be found here [Data Graphs Support](https://support.datagraphs.io)
 
+## Supply-chain safeguards
+
+`.npmrc` sets `ignore-scripts=true` so dependency install scripts never run during `npm ci` — including in the GitHub Actions publish jobs, where the npm publish token is in the environment. Do not remove this setting.
+
 ## Install
 
 ```sh


### PR DESCRIPTION
Add .npmrc with ignore-scripts=true so dependency install scripts never run during `npm ci` — including the GitHub Actions publish jobs (publish-npm / publish-gpr), where the publish token (secrets.npm_token / GITHUB_TOKEN) is in the environment and a malicious postinstall could exfiltrate it.

Published-SDK scope: engines.node is intentionally left unset (raising it is a demand on every consumer). The min-release-age cooldown and lockfile/signature CI checks are deferred — the publish workflow runs on Node 12 / npm 6, which predates the npm versions that support them.